### PR TITLE
fixed issue with statuses persisting into negative duration

### DIFF
--- a/entities/heroes/specifics/bc/bc-status/bc_slow.gd
+++ b/entities/heroes/specifics/bc/bc-status/bc_slow.gd
@@ -22,8 +22,10 @@ func simulate(hero, state):
 	h_id = state["h_id"]
 	hero.modify_speed(1)
 	duration -= delta
+	var node = self
+	var parent = get_parent()
 	if duration < 0:
-		interactions.append(func(): queue_free(); print("done"))
+		interactions.append(func(): free())
 	return interactions
 
 func get_state():

--- a/game/entities/heroes/common/hero_status_manager.gd
+++ b/game/entities/heroes/common/hero_status_manager.gd
@@ -12,6 +12,7 @@ func init(h: Hero):
 func drop_freed(unit_statuses: Dictionary):
 	for child in get_children():
 		if not child.id in unit_statuses:
+			print("freeing", child.id)
 			child.queue_free()
 
 func apply_status(status : HeroStatus):
@@ -19,7 +20,6 @@ func apply_status(status : HeroStatus):
 
 func simulate(unit_statuses, input: PlayerInput):
 	unit_statuses = unit_statuses["unit_statuses"]
-	print(unit_statuses)
 	var interactions = []
 	for child in get_children():
 		if child.id in unit_statuses:
@@ -28,6 +28,8 @@ func simulate(unit_statuses, input: PlayerInput):
 			interactions += interaction
 			unit_statuses.erase(child.id)
 	for id in unit_statuses:
+		if multiplayer.is_server():
+			print("status creation")
 		#super scuffed rn to get smth working
 		var entities = hero.get_parent()
 		for entity in entities.get_children():
@@ -41,6 +43,7 @@ func simulate(unit_statuses, input: PlayerInput):
 func get_state():
 	var end_states = {}
 	for child in get_children():
+		if multiplayer.is_server():
+			print("status_man get_state", child.get_state())
 		end_states[child.id] = child.get_state()
-	print(end_states)
 	return {"unit_statuses" : end_states}

--- a/game/world/game_controller.gd
+++ b/game/world/game_controller.gd
@@ -245,6 +245,9 @@ func state_update(states: GameState, inputs: Dictionary):
 		var id = child.controller_id
 		if id in states.players:
 			states.players[id] = child.get_state()
+			if multiplayer.is_server():
+				print(child.status_manager.get_children())
+				print(child.status_manager.get_state())
 	
 	arena.update_state(states.arena)
 	return states


### PR DESCRIPTION
Important change:
entities/heroes/specifics/bc/bc-status/bc_slow.gd
func(): queue_free()
func(): free()

queue_free() was causing issues as the object was persisting through the frame, and being returned in get_state, which allowed negative duration statuses to continue existing.