### PR TITLE
Fixed BcSlow not applying properly

### DIFF
--- a/entities/heroes/specifics/bc/bc-status/bc_slow.gd
+++ b/entities/heroes/specifics/bc/bc-status/bc_slow.gd
@@ -20,12 +20,12 @@ func simulate(hero, state):
 	var delta = get_physics_process_delta_time()
 	duration = state["duration"]
 	h_id = state["h_id"]
-	hero.modify_speed(1)
+	hero.modify_speed(0.1)
 	duration -= delta
 	var node = self
 	var parent = get_parent()
 	if duration < 0:
-		interactions.append(func(): free())
+		interactions.append(func(): parent.remove_child(node); queue_free())
 	return interactions
 
 func get_state():

--- a/game/entities/heroes/common/base_hero.gd
+++ b/game/entities/heroes/common/base_hero.gd
@@ -79,14 +79,16 @@ func simulate(state: PlayerState, input: PlayerInput):
 	unit_manager.derivatives_count = state.derivatives["d_count"]
 	unit_manager.drop_freed(state.derivatives["unit_states"])
 	status_manager.drop_freed(statuses["unit_statuses"])
-	var sm_interactions = state_manager.simulate(hs, input)
-	interactions += (sm_interactions)
+	
+	var status_interactions = status_manager.simulate(statuses, input)
+	interactions += status_interactions
+	
+	var state_interactions = state_manager.simulate(hs, input)
+	interactions += (state_interactions)
 	
 	var unit_interactions = unit_manager.simulate(state.derivatives, input)
 	interactions += unit_interactions
 	
-	var status_interactions = status_manager.simulate(statuses, input)
-	interactions += status_interactions
 	
 	return interactions
 

--- a/game/entities/heroes/common/hero_movement.gd
+++ b/game/entities/heroes/common/hero_movement.gd
@@ -17,7 +17,7 @@ func reset():
 	modified_speed = DEFAULT_SPEED
 
 func modify_speed(percentage):
-	modified_speed = percentage
+	modified_speed *= percentage
 
 func move(target: Vector2, delta: float) -> void:
 	var dirn: Vector3 = Vector3(

--- a/game/entities/heroes/common/hero_status_manager.gd
+++ b/game/entities/heroes/common/hero_status_manager.gd
@@ -12,7 +12,6 @@ func init(h: Hero):
 func drop_freed(unit_statuses: Dictionary):
 	for child in get_children():
 		if not child.id in unit_statuses:
-			print("freeing", child.id)
 			child.queue_free()
 
 func apply_status(status : HeroStatus):
@@ -28,8 +27,6 @@ func simulate(unit_statuses, input: PlayerInput):
 			interactions += interaction
 			unit_statuses.erase(child.id)
 	for id in unit_statuses:
-		if multiplayer.is_server():
-			print("status creation")
 		#super scuffed rn to get smth working
 		var entities = hero.get_parent()
 		for entity in entities.get_children():
@@ -43,7 +40,5 @@ func simulate(unit_statuses, input: PlayerInput):
 func get_state():
 	var end_states = {}
 	for child in get_children():
-		if multiplayer.is_server():
-			print("status_man get_state", child.get_state())
 		end_states[child.id] = child.get_state()
 	return {"unit_statuses" : end_states}

--- a/game/entities/heroes/common/hero_status_manager.gd
+++ b/game/entities/heroes/common/hero_status_manager.gd
@@ -15,6 +15,9 @@ func drop_freed(unit_statuses: Dictionary):
 			child.queue_free()
 
 func apply_status(status : HeroStatus):
+	for child in get_children():
+		if child.id == status.id:
+			child.queue_free()
 	add_child(status)
 
 func simulate(unit_statuses, input: PlayerInput):

--- a/game/entities/heroes/specifics/bc/bc_attack.gd
+++ b/game/entities/heroes/specifics/bc/bc_attack.gd
@@ -59,7 +59,7 @@ func simulate(unit_states):
 	
 	lifespan -= delta
 	if lifespan < 0:
-		interactions.append(func(): queue_free())
+		interactions.append(func(): free())
 	return interactions
 
 

--- a/game/entities/heroes/specifics/bc/bc_first.gd
+++ b/game/entities/heroes/specifics/bc/bc_first.gd
@@ -51,7 +51,7 @@ func simulate(unit_states):
 			lifespan = -1	#remove
 	lifespan -= delta
 	if lifespan < 0:
-		interactions.append(func(): queue_free())
+		interactions.append(func(): free())
 	return interactions
 
 

--- a/game/world/game_controller.gd
+++ b/game/world/game_controller.gd
@@ -245,9 +245,6 @@ func state_update(states: GameState, inputs: Dictionary):
 		var id = child.controller_id
 		if id in states.players:
 			states.players[id] = child.get_state()
-			if multiplayer.is_server():
-				print(child.status_manager.get_children())
-				print(child.status_manager.get_state())
 	
 	arena.update_state(states.arena)
 	return states


### PR DESCRIPTION
Description of issue:

`for child in get_children():
	if not child.id in unit_statuses:
		child.queue_free()`

`for child in get_children():
        if child.id in unit_statuses:
            var unit_status = unit_statuses[child.id]
            var interaction = child.simulate(hero, unit_status)
            interactions += interaction
            unit_statuses.erase(child.id)`

Character had Slow1 (1sec left)
then add Slow2 (5sec left)
Return the states.
states["BcSlow"] would be 5sec duration because Slow1 and Slow2 share the same id

drop_freed does not delete Slow1 or Slow2 because they share the same id

Then simulate updates Slow1 to the given state (5sec)
then the state is erased from the dictionary
Now Slow2 doesnt update because it isnt in the dictionary

Fix:
`func apply_status(status : HeroStatus):
    for child in get_children():
        if child.id == status.id:
            child.queue_free()
    add_child(status)`
For statuses with the same id, remove the older one and attach the new one